### PR TITLE
fix: 统一为北京时间0点更新题目，防止各地更新时间不统一

### DIFF
--- a/src/logic/constants.ts
+++ b/src/logic/constants.ts
@@ -1,5 +1,8 @@
 export const WORD_LENGTH = 4
 export const TRIES_LIMIT = 10
-export const START_DATE = new Date(2022, 0, 0)
+const START_DATE = new Date(2022, 0, 0)
+START_DATE.setUTCFullYear(2022, 0, 0)
+START_DATE.setUTCHours(-8, 0, 0, 0)
+export { START_DATE }
 export const RANDOM_SEED = 'handle'
 export const DAYS_PLAY_BACK = 3


### PR DESCRIPTION
之前和在英国的朋友一起玩，发现做的不是同一题。看看是否统一更新时间为北京时间0点？