### PR TITLE
fix: character match with some characters

### DIFF
--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -84,7 +84,7 @@ export function testAnswer(input: ParsedChar[], answer: ParsedChar[]) {
   return input.map((a, i): MatchResult => {
     const char = toSimplified(a.char)
     return {
-      char: answer[i].char === char
+      char: answer[i].char === char || answer[i].char === a.char
         ? 'exact'
         : includesAndRemove(unmatched.char, char)
           ? 'misplaced'


### PR DESCRIPTION
Some characters can be both traditional and simplified. When this is the case for some answers, the game will not end because even when the player input the correct character, it gets translated into a wrong one.

Example: 著于竹帛
著 will be turned into 着 and the game will continue since the character is considered a mismatch.