### PR TITLE
feat: add result data to finished page

### DIFF
--- a/src/components/Countdown.vue
+++ b/src/components/Countdown.vue
@@ -13,7 +13,7 @@ const formatted = computed(() => {
 </script>
 
 <template>
-  <div flex gap-5 py8>
+  <div flex gap-5 pb8>
     <div flex="~ col center" relative w-38>
       <div op80 ws-nowrap>
         {{ t('next-note') }}

--- a/src/components/ExportImage.vue
+++ b/src/components/ExportImage.vue
@@ -69,7 +69,7 @@ async function download() {
       </div>
 
       <WordBlocks v-for="w,i of tries" :key="i" :word="w" :revealed="true" :animate="false" />
-      <ResultFooter w-344px />
+      <ResultFooter />
     </div>
   </div>
 </template>

--- a/src/components/Play.vue
+++ b/src/components/Play.vue
@@ -157,8 +157,10 @@ watchEffect(() => {
       </template>
       <template v-else>
         <ResultFooter />
+        <div mt-10 />
         <Countdown />
         <ToggleMask />
+        <div mt-10 />
       </template>
 
       <template v-if="isDev">

--- a/src/components/Play.vue
+++ b/src/components/Play.vue
@@ -156,6 +156,7 @@ watchEffect(() => {
         </div>
       </template>
       <template v-else>
+        <ResultFooter />
         <Countdown />
         <ToggleMask />
       </template>

--- a/src/components/ResultFooter.vue
+++ b/src/components/ResultFooter.vue
@@ -5,7 +5,7 @@ import { t } from '~/i18n'
 </script>
 
 <template>
-  <div relative op50 my2 text-sm min-h-1em w-344px>
+  <div relative op50 my2 text-sm min-h-1em w-86>
     <div absolute text-sm left-0 bottom-0 ws-nowrap>
       D{{ dayNo }} · {{ meta.hintLevel ? meta.hintLevel + t('hint-level') : t('hint-level-none') }}
     </div>

--- a/src/components/ResultFooter.vue
+++ b/src/components/ResultFooter.vue
@@ -5,7 +5,7 @@ import { t } from '~/i18n'
 </script>
 
 <template>
-  <div relative op50 my2 text-sm min-h-1em>
+  <div relative op50 my2 text-sm min-h-1em w-344px>
     <div absolute text-sm left-0 bottom-0 ws-nowrap>
       D{{ dayNo }} · {{ meta.hintLevel ? meta.hintLevel + t('hint-level') : t('hint-level-none') }}
     </div>


### PR DESCRIPTION
Hello~ My girlfriend is also playing this game. When she guessed the answer, she said it would be better if there has specific use time.

I look the code has `duration` variable, but only show in share image. Now I put `ResultFooter` component on finished page. Hope you have time to see if it makes sense to do this? Thanks.

This is the UI after adding the component.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/29054821/155878446-07fa97c0-046e-4e1e-be2d-d7cf2a440e5e.png">


