### PR TITLE
Display ü correctly

### DIFF
--- a/src/components/CharBlock.vue
+++ b/src/components/CharBlock.vue
@@ -85,10 +85,14 @@ const partTwo = computed(() => {
   const two = props.char?._2 || ''
   const oneLength = props.char?._1?.length || 0
   const index = toneCharLocation.value - oneLength
+
+  let result = two
   // replace i with dot less for tone symbol
   if (!useNumberTone.value && props.char?.yin[toneCharLocation.value] === 'i')
-    return `${two.slice(0, index)}ı${two.slice(index + 1)}`
-  return two
+    result = `${result.slice(0, index)}ı${result.slice(index + 1)}`
+
+  // replace v with standard notation ü
+  return result.replace("v", "ü")
 })
 </script>
 

--- a/src/components/CheatSheet.vue
+++ b/src/components/CheatSheet.vue
@@ -19,6 +19,10 @@ function close() {
   showCheatSheet.value = false
 }
 
+function pinyinPostProcess(pinyin: string) {
+  return pinyin.replace("v", "ü")
+}
+
 const modeText = computed(() => ({
   py: t('pinyin'),
   sp: t('shuangpin'),
@@ -77,7 +81,7 @@ const modeText = computed(() => ({
       </div>
       <div grid="~ cols-3 gap-3" h-min>
         <div v-for="s of pinyinFinals" :key="s" :class="getSymbolClass(s)">
-          {{ s }}
+          {{ pinyinPostProcess(s) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Displays ü correctly in the cheatsheet and the character block.

Implements #21