### PR TITLE
Fix daylight saving time countdown error

### DIFF
--- a/netlify/date.ts
+++ b/netlify/date.ts
@@ -1,2 +1,16 @@
-export const START_DATE = new Date(2022, 0, 0)
-export const dayNo = Math.floor((Date.now() - +START_DATE) / 86400000)
+export const START_DATE = new Date(2022, 0, 0) // not daylight saving time
+const date = new Date();
+/**
+ * Checks whether a given date is in daylight saving time.
+ * @param date the date object to be checked.
+ * @returns true if the date is in daylight saving time, false if it's not.
+ */
+const isDST = (date: Date) => {
+    const jan = new Date(date.getFullYear(), 0, 1);
+    const jul = new Date(date.getFullYear(), 6, 1);
+    const standardTimezoneOffset = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+    return date.getTimezoneOffset() < standardTimezoneOffset;
+}
+// Patch now to ignore DST, matching START_DATE (not DST)
+const now = isDST(date) ? new Date(+date + 3600000).valueOf() : date.valueOf();
+export const dayNo = Math.floor((now - +START_DATE) / 86400000)

--- a/src/components/Countdown.vue
+++ b/src/components/Countdown.vue
@@ -2,8 +2,7 @@
 import { now } from '~/state'
 import { t } from '~/i18n'
 import { START_DATE } from '~/logic'
-
-const ms = computed(() => 86400000 - (+now.value - +START_DATE) % 86400000)
+const ms = computed(() => 86400000 - ((now.value.isDstObserved() ? +now.value + 3600000 : +now.value) - +START_DATE) % 86400000)
 const formatted = computed(() => {
   const h = Math.floor((ms.value % 86400000) / 3600000)
   const m = Math.floor((ms.value % 3600000) / 60000)

--- a/src/logic/dateExt.ts
+++ b/src/logic/dateExt.ts
@@ -1,0 +1,14 @@
+interface Date {
+    stdTimezoneOffset: () => number;
+    isDstObserved: () => boolean;
+}
+
+Date.prototype.stdTimezoneOffset = function () {
+    var jan = new Date(this.getFullYear(), 0, 1);
+    var jul = new Date(this.getFullYear(), 6, 1);
+    return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+};
+
+Date.prototype.isDstObserved = function () {
+    return this.getTimezoneOffset() < this.stdTimezoneOffset();
+};

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,6 +3,7 @@ import type { MatchType, ParsedChar } from './logic'
 import { START_DATE, TRIES_LIMIT, WORD_LENGTH, parseWord as _parseWord, testAnswer as _testAnswer, checkPass, getHint, numberToHanzi } from './logic'
 import { useNumberTone as _useNumberTone, inputMode, meta, spMode, tries } from './storage'
 import { getAnswerOfDay } from './answers'
+import './logic/dateExt.ts'
 
 export const isIOS = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
 export const isMobile = isIOS || /iPad|iPhone|iPod|Android|Phone|webOS/i.test(navigator.userAgent)
@@ -32,7 +33,11 @@ export const useNumberTone = computed(() => {
 
 const params = new URLSearchParams(window.location.search)
 export const isDev = import.meta.hot || params.get('dev') === 'hey'
-export const daySince = useDebounce(computed(() => Math.floor((+now.value - +START_DATE) / 86400000)))
+export const daySince = useDebounce(computed(() => {
+  // Adjust date for daylight saving time, assuming START_DATE is not in DST
+  const adjustedNow = now.value.isDstObserved() ? new Date(+now.value + 3600000) : now.value
+  return Math.floor((+adjustedNow - +START_DATE) / 86400000)
+}))
 export const dayNo = ref(+(params.get('d') || daySince.value))
 export const dayNoHanzi = computed(() => `${numberToHanzi(dayNo.value)}日`)
 export const answer = computed(() =>


### PR DESCRIPTION
Fixes #56 
The bug emerges for all countries that observe DST.
Since the constant `START_DATE` isn't in DST, when we enter in DST, an hour gap is created.. 
I edited lines where we compare `now` and `START_DATE`..
To test this, I changed my computer's region/date time to several countries _with_ DST, the countdown is now correct.

Not being familiar with Netlify, I edited `date.ts` too, since it has the same logic..