### PR TITLE
fix: hanzi regexp

### DIFF
--- a/packages/tools/src/hanzi/filter.ts
+++ b/packages/tools/src/hanzi/filter.ts
@@ -1,6 +1,6 @@
 export function filterNonChineseChars(input: string) {
   return Array.from(input)
-    .filter(i => /\p{Script=Han}/u.test(i))
+    .filter(i => /\p{Unified_Ideograph}/u.test(i))
     .join('')
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

> `/\p{Script=Han}/u` 囊括了所有统一表意文字、中日韩兼容性字符、苏州码子、「〇」、「〆」、「々」以及字典常用的部首。从前面汉文（Han Script）与汉字（CJK Ideograph）的关系我们可以知道，`/\p{Script=Han}/u`匹配的是汉文作为一个字符集里面的所有字符，因此它包括了部首、「々」等字符，这些字符要么当它们独立存在的时候没有语言意义（部首独立存在是一个符号），要么无法独立存在（「々」依赖于所修饰的汉字）。所以汉字是汉文的一个单元，汉文除了包含汉字以外，还包括这些符号、数字、修饰符。因此使用`/\p{Script=Han}/u`来匹配汉字是混淆了汉文与汉字的概念范围。

目前的汉字正则并不精确

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

No


### Additional context

参考：https://zhuanlan.zhihu.com/p/33335629

<!-- e.g. is there anything you'd like reviewers to focus on? -->
