### PR TITLE
fix: empty answer

### DIFF
--- a/src/answers/list.ts
+++ b/src/answers/list.ts
@@ -49,7 +49,7 @@ function prepare<T>(len: number, arr: T[]) {
   return arr
 }
 
-export const _PRE = prepare(1, [[]])
+export const _PRE = prepare(1, [['时运亨通', '运']])
 
 export const _2022_JAN = prepare(31, [
   ['路不拾遗', '遗'],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

修复空题目问题。

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#95 

### Additional context

https://github.com/antfu/handle/blob/78ea2f99959551d9370e6a415701ae39f7ed23d7/src/answers/index.ts#L10

原因是这里 `Math.floor(seed * answers.length)` 计算结果是 0，然后取到了空题目。2024-08-11 这天也出现了这个问题。

<!-- e.g. is there anything you'd like reviewers to focus on? -->
